### PR TITLE
Add unit tests for acheter view

### DIFF
--- a/shop/boutique/tests.py
+++ b/shop/boutique/tests.py
@@ -1,0 +1,37 @@
+from django.test import TestCase, Client
+from django.conf import settings
+from unittest.mock import patch, MagicMock
+from django.urls import reverse
+
+# Use SQLite for tests to avoid requiring PostgreSQL
+settings.DATABASES["default"].update(
+    {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+)
+
+
+class AcheterViewTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def test_get_acheter_returns_page(self):
+        response = self.client.get(reverse('acheter'))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '<h2>Acheter un maillot</h2>', html=True)
+
+    @patch('boutique.views.pika.BlockingConnection')
+    def test_post_acheter_sends_message(self, mock_connection):
+        mock_channel = MagicMock()
+        mock_connection.return_value.channel.return_value = mock_channel
+
+        response = self.client.post(reverse('acheter'))
+
+        self.assertEqual(response.status_code, 200)
+        mock_connection.assert_called()
+        mock_channel.queue_declare.assert_called_with(queue='commandes')
+        mock_channel.basic_publish.assert_called_with(
+            exchange='', routing_key='commandes', body='maillot acheté'
+        )
+        self.assertContains(response, 'Commande envoyée avec succès !')

--- a/shop/shop/settings.py
+++ b/shop/shop/settings.py
@@ -57,6 +57,16 @@ DATABASES = {
     }
 }
 
+# Utilise SQLite en mode test pour simplifier l'exécution des tests unitaires
+import sys
+if 'test' in sys.argv:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': ':memory:',
+        }
+    }
+
 LANGUAGE_CODE = 'fr-fr'
 TIME_ZONE = 'UTC'
 USE_I18N = True


### PR DESCRIPTION
## Summary
- create tests for the boutique acheter view
- ensure test database uses SQLite by default when running tests

## Testing
- `cd shop && python manage.py test && cd ..`


------
https://chatgpt.com/codex/tasks/task_e_68497c317d8c83289de4181749c9fb8d