### PR TITLE
Fix CI Django paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,10 @@ jobs:
       - name: Run migrations
         env:
           DJANGO_DB_HOST: localhost
-        run: python manage.py migrate
+        run: python shop/manage.py migrate
 
       - name: Run tests
-        run: python manage.py test
+        run: python shop/manage.py test
 
   sonar:
     needs: test


### PR DESCRIPTION
## Summary
- fix workflow to use the Django project directory when running migrations and tests

## Testing
- `pip install -r requirements.txt`
- `python shop/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684a91b1dc2883289cbe0eb371c3c492